### PR TITLE
Use cookie file for authentication

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Build and publish to GitHub Packages
+name: Build and Publish GitHub Packages
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -14,7 +14,6 @@ jobs:
   bitcoin_core:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/bitcoin-core/Dockerfile
+++ b/bitcoin-core/Dockerfile
@@ -22,4 +22,6 @@ COPY --from=install /usr/bin/bitcoin-cli /usr/bin/bitcoin-cli
 
 EXPOSE 8332 8333 18332 18333 18443 18444
 
-CMD ["sh", "-c", "/usr/bin/bitcoind -$NETWORK -server -rest -rpcbind=0.0.0.0 -rpcallowip=0.0.0.0/0 -rpcuser=$RPC_USER -rpcpassword=$RPC_PASS -fallbackfee=$FALLBACKFEE"]
+VOLUME /data
+
+CMD ["sh", "-c", "/usr/bin/bitcoind -$NETWORK -server -rest -rpcport=$RPC_PORT -rpcbind=0.0.0.0 -rpcallowip=0.0.0.0/0 -fallbackfee=$FALLBACKFEE -datadir=/data"]

--- a/bitcoin-core/README.md
+++ b/bitcoin-core/README.md
@@ -4,7 +4,7 @@
 Build the image against `ubuntu:20.04` with
 
 ```
-docker build --build-arg VRS=0.21.1 -t ...:latest .
+docker build --build-arg VRS=0.21.1 -t bitcoind:latest .
 ```
 
 Available `build-arg`:
@@ -19,16 +19,15 @@ docker create -p 18443:18443\
     --env FALLBACKFEE=0.00001\
     --env RPC_PORT=18443
     --name bitcoind\
-    ...:latest
+    bitcoind:latest
 ```
 
-The bitcoin datadir is in the /data volume and can be accessed by addtionally passing for example `-v /path/to/host/folder:data` to `docker create`.
+The bitcoin datadir is in the /data volume and can be accessed by addtionally passing for example `-v /path/to/host/folder:data` to `docker create` or create a named volume with `docker volume create --name bitcoind-data` and use the flag `-v bitcoind-data:/data`.
 
 Available environment variables:
 
 - **NETWORK**: a flag intended for the network, but this can be used more broadly as it is directly passed to `bitcoind` with a prepended `-`
-- **RPC_USER**: the RPC user name
-- **RPC_PASS**: the RPC password
+- **RPC_PORT**: the RPC port to bind
 - **FALLBACKFEE**: the fallbackfee parameter
 
 RPC is binded to `0.0.0.0` and accept connection from everywhere.
@@ -53,16 +52,19 @@ All the ports are exposed by defaut. `bitcoin-cli` is also installed.
 ## Standalone usage
 
 ```
+docker pull ghcr.io/farcaster-project/containers/bitcoin-core:latest
+docker volume create --name bitcoind-data
 ID=$(docker create -p 18443:18443\
     --name bitcoind\
     --env NETWORK=regtest\
     --env RPC_PORT=18443\
     --env FALLBACKFEE=0.00001\
-    -v ~/data_dir:/data\
+    -v bitcoind-data:/data\
     ghcr.io/farcaster-project/containers/bitcoin-core:latest)
 
 docker start $ID
 ...
 docker kill $ID
 docker container rm $ID
+docker volume rm bitcoind-data
 ```

--- a/bitcoin-core/README.md
+++ b/bitcoin-core/README.md
@@ -15,16 +15,18 @@ Create a container with
 
 ```
 docker create -p 18443:18443\
-    --env RPC_USER=...\
-    --env RPC_PASS=...\
     --env NETWORK=regtest\
     --env FALLBACKFEE=0.00001\
+    --env RPC_PORT=18443
+    --name bitcoind\
     ...:latest
 ```
 
+The bitcoin datadir is in the /data volume and can be accessed by addtionally passing for example `-v /path/to/host/folder:data` to `docker create`.
+
 Available environment variables:
 
-- **NETWORK**: a flag inteded for the network, but this can be used more broadly as it is directly passed to `bitcoind` with a prepended `-`
+- **NETWORK**: a flag intended for the network, but this can be used more broadly as it is directly passed to `bitcoind` with a prepended `-`
 - **RPC_USER**: the RPC user name
 - **RPC_PASS**: the RPC password
 - **FALLBACKFEE**: the fallbackfee parameter
@@ -41,9 +43,9 @@ All the ports are exposed by defaut. `bitcoin-cli` is also installed.
         image: ghcr.io/farcaster-project/containers/bitcoin-core
         env:
           NETWORK: regtest
-          RPC_USER: ci
-          RPC_PASS: ${{ secrets.RPC_PASS }}
+          RPC_PORT: 18443
           FALLBACKFEE: "0.00001"
+        options: -v ~/data_dir:/data
         ports:
           - 18443:18443
 ```
@@ -52,10 +54,11 @@ All the ports are exposed by defaut. `bitcoin-cli` is also installed.
 
 ```
 ID=$(docker create -p 18443:18443\
+    --name bitcoind\
     --env NETWORK=regtest\
-    --env RPC_USER=test\
-    --env RPC_PASS=cEl2o3tHHgzYeuu3CiiZ2FjdgSiw9wNeMFzoNbFmx9k=\
+    --env RPC_PORT=18443\
     --env FALLBACKFEE=0.00001\
+    -v ~/data_dir:/data\
     ghcr.io/farcaster-project/containers/bitcoin-core:latest)
 
 docker start $ID


### PR DESCRIPTION
Removes the rpcuser and rpcpassword options in favor of the cookie file. The cookie file is automatically generated into the /data volume. This volume can be accessed by outside applications to get the required authentication credentials.