### PR TITLE
Build and publish monero-lws in CI

### DIFF
--- a/.github/workflows/monero-lws.yml
+++ b/.github/workflows/monero-lws.yml
@@ -1,0 +1,29 @@
+name: Monero LWS
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'monero-lws/Dockerfile'
+
+jobs:
+  monero-lws:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Docker build
+      run: docker build -f $GITHUB_WORKSPACE/monero-lws/Dockerfile -t ghcr.io/farcaster-project/containers/monero-lws:latest $GITHUB_WORKSPACE/monero-lws
+
+    - name: Docker push to GitHub Packages
+      run:  |
+          docker push ghcr.io/farcaster-project/containers/monero-lws:latest

--- a/monero-lws/README.md
+++ b/monero-lws/README.md
@@ -1,4 +1,4 @@
-# `monero-lws-daemon` container
+# `monero-lws` container
 
 Build the image against `ubuntu:20.04` with
 
@@ -38,7 +38,7 @@ docker create -p 38084:38084\
     --link monerod\
     --env MONEROD_ADDRESS=monerod:18082\
     --env NETWORK=main\
-    ghcr.io/farcaster-project/containers/monero-lws-daemon:latest
+    ghcr.io/farcaster-project/containers/monero-lws:latest
 
 docker start monerod
 docker start monero-lws-daemon

--- a/monero-lws/README.md
+++ b/monero-lws/README.md
@@ -3,18 +3,18 @@
 Build the image against `ubuntu:20.04` with
 
 ```
-docker build -t monero-lws-daemon:latest .
+docker build -t monero-lws:latest .
 ```
 
 Create a container with
 
 ```
 docker create -p 38084:38084\
-    --name monero-lws-daemon\
+    --name monero-lws\
     --env MONEROD_ADDRESS=monerod:18082\
     --env NETWORK=main\
     --link monerod\
-    monero-lws-daemon:latest
+    monero-lws:latest
 ```
 
 Available environment variables:
@@ -34,17 +34,17 @@ docker create -p 18081:18081\
     ghcr.io/farcaster-project/containers/monerod:latest
 
 docker create -p 38084:38084\
-    --name monero-lws-daemon\
+    --name monero-lws\
     --link monerod\
     --env MONEROD_ADDRESS=monerod:18082\
     --env NETWORK=main\
     ghcr.io/farcaster-project/containers/monero-lws:latest
 
 docker start monerod
-docker start monero-lws-daemon
+docker start monero-lws
 
 ...
 
-docker kill monerod monero-lws-daemon
-docker container rm monerod monero-lws-daemon
+docker kill monerod monero-lws
+docker container rm monerod monero-lws
 ```


### PR DESCRIPTION
Adds the build and publish in CI for monero-lws introduced in #10 

@TheCharlatan I don't know if you want to use `monero-lws-daemon` or `monero-lws`, if I picked the wrong one feel free to change it.