### PR TITLE
Smarter static analysis workflow run

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -3,8 +3,12 @@ name: Static Analysis
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.md'
 
 jobs:
   mdfmt:


### PR DESCRIPTION
Fix #35

Only run static analysis when a Markdown path is touched.