### PR TITLE
fix(dockerfile): fix monero-lws compilation on Mac

### DIFF
--- a/monero-lws/Dockerfile
+++ b/monero-lws/Dockerfile
@@ -39,7 +39,7 @@ RUN git clone https://github.com/monero-project/monero && \
     git checkout v$MNRTAG && \
     git submodule init && git submodule update && \
     mkdir build && cd build && \
-    cmake -DCMAKE_CXX_FLAGS="-mno-avx512f" -DCMAKE_C_FLAGS="-mno-avx512f" .. && \
+    cmake .. && \
     make -j$(nproc)
 
 # build monero-lws


### PR DESCRIPTION
Closes #63 

Monero compilation wasn't working on Mac with `-DCMAKE_CXX_FLAGS="-mno-avx512f" -DCMAKE_C_FLAGS="-mno-avx512f"`