### PR TITLE
Revert "fix(dockerfile): fix monero-lws compilation on Mac (#64)"

### DIFF
--- a/monero-lws/Dockerfile
+++ b/monero-lws/Dockerfile
@@ -39,7 +39,7 @@ RUN git clone https://github.com/monero-project/monero && \
     git checkout v$MNRTAG && \
     git submodule init && git submodule update && \
     mkdir build && cd build && \
-    cmake .. && \
+    cmake -DCMAKE_CXX_FLAGS="-mno-avx512f" -DCMAKE_C_FLAGS="-mno-avx512f" .. && \
     make -j$(nproc)
 
 # build monero-lws


### PR DESCRIPTION
This reverts commit bccbf674c4118d07c44e1bdf33aebbc917914a61.

As mentioned in #64 the patch makes the container crash at start on Linux at least. This blocks CI update on node.