### PR TITLE
Allow mismatched daemon version for monero wallet RPC

### DIFF
--- a/monero-wallet-rpc/Dockerfile
+++ b/monero-wallet-rpc/Dockerfile
@@ -23,4 +23,4 @@ EXPOSE 18083 28083 38083
 
 LABEL "org.opencontainers.image.description"="A ready to use monero wallet-rpc image suited for CI and tests."
 
-CMD ["sh", "-c", "/usr/bin/monero-wallet-rpc --disable-rpc-login --wallet-dir wallets --daemon-address $MONERO_DAEMON_ADDRESS --rpc-bind-ip 0.0.0.0 --rpc-bind-port $WALLET_RPC_PORT --confirm-external-bind --trusted-daemon"]
+CMD ["sh", "-c", "/usr/bin/monero-wallet-rpc --disable-rpc-login --wallet-dir wallets --daemon-address $MONERO_DAEMON_ADDRESS --rpc-bind-ip 0.0.0.0 --rpc-bind-port $WALLET_RPC_PORT --confirm-external-bind --trusted-daemon --allow-mismatched-daemon-version"]


### PR DESCRIPTION
This fix
```
Unexpected hard fork version v16 at height 1. Make sure the node you are connected to is running the latest version
```

Resource: [monero-project/monero#8600](https://github.com/monero-project/monero/issues/8600#issuecomment-1262147973)